### PR TITLE
Adds TLS 1.2 flag to existing value

### DIFF
--- a/CodeShare.TLS1.2.Umbraco/EventHandlers/RegisterEvents.cs
+++ b/CodeShare.TLS1.2.Umbraco/EventHandlers/RegisterEvents.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Core;
+﻿using System.Net;
+using Umbraco.Core;
 
 namespace CodeShare.TLS1._2.Umbraco.EventHandlers
 {
@@ -6,7 +7,10 @@ namespace CodeShare.TLS1._2.Umbraco.EventHandlers
     {
         protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
         {
-            System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
+            if (ServicePointManager.SecurityProtocol.HasFlag(SecurityProtocolType.Tls12) == false)
+            {
+                ServicePointManager.SecurityProtocol = ServicePointManager.SecurityProtocol | SecurityProtocolType.Tls12;
+            }
         }
     }
 }


### PR DESCRIPTION
The [`SecurityProtocol` property](https://docs.microsoft.com/en-us/dotnet/api/system.net.servicepointmanager.securityprotocol?view=netframework-4.7.2) is a flagged enum, so can have a combination of values.

There could be a scenario where another security protocol (e.g. SSL 3.0) may be used in as well as TLS 1.2.

This patch explicitly checks if TLS 1.2 is enabled, if not, it adds the enum flag to the existing value.